### PR TITLE
Allow watcher to detect Visual Studio changes.

### DIFF
--- a/XamlWatcher.WPF/Watcher.cs
+++ b/XamlWatcher.WPF/Watcher.cs
@@ -23,6 +23,7 @@ namespace XamlWatcher.WPF
                 EnableRaisingEvents = true
             };
             watcher.Changed += watcher_Changed;
+            watcher.Renamed += watcher_Changed;
         }
 
         public Action<Exception> OnError { get; set; }


### PR DESCRIPTION
Visual Studio will often save files under a different name, and then rename them. This
means that the watcher will not detect these changes. Adding a "Renamed" handler
allows these changes to be detected.
